### PR TITLE
corrected address overlap with map in mobile view

### DIFF
--- a/contact.css
+++ b/contact.css
@@ -148,6 +148,10 @@ hr {
 /*Adjustment to make address show above map which has z-index of 3*/
 @media screen and (max-device-width: 800px), screen and (max-width:800px) {
 .info-block-resp{
-  z-index: 3;
+  position: relative;
+  display: contents;
 }
+}
+.position-map{
+  width: 100%;
 }

--- a/contact.html
+++ b/contact.html
@@ -99,7 +99,10 @@
             </section>
         </div>
         <!--mapsection-->
-        <div id="map" ></div>
+        <div class="position-map">
+          <div id="map" ></div>
+        </div>
+        
 
     </div>
     <!--footer-->


### PR DESCRIPTION
Corrected address overlap with map using mediaquery and setting display of address to content at breakpoint. 